### PR TITLE
Dependency graph uploads can be flaky

### DIFF
--- a/action-build-gradle-pr/action.yml
+++ b/action-build-gradle-pr/action.yml
@@ -76,6 +76,8 @@ runs:
     - name: Generate and submit dependency graph
       if: github.event_name != 'pull_request'
       uses: gradle/actions/dependency-submission@v6
+      with:
+        dependency-graph-continue-on-failure: true
 
     - name: 'Upload Gradle Artifact'
       uses: actions/upload-artifact@v7

--- a/action-build-gradle/action.yml
+++ b/action-build-gradle/action.yml
@@ -84,6 +84,8 @@ runs:
     - name: Generate and submit dependency graph
       if: github.event_name != 'pull_request'
       uses: gradle/actions/dependency-submission@v6
+      with:
+        dependency-graph-continue-on-failure: true
 
     - name: 'Upload Gradle Artifact'
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
We don't want to fail the build if we can't upload the
dependency graph because the depedency graph isn't critical and
a failure means re-running long running jobs that wastes time and
effort.
