### PR TITLE
Add shared orchestrator setup action

### DIFF
--- a/action-orchestrator-setup/action.yml
+++ b/action-orchestrator-setup/action.yml
@@ -35,32 +35,39 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Add orchestrator context to summary
-      if: ${{ inputs.orchestrator-run-suffix != '' }}
+    - name: Prepare orchestrator runtime
       shell: bash
+      env:
+        ORCHESTRATOR_RUN_SUFFIX: ${{ inputs.orchestrator-run-suffix }}
+        ENTERPRISE_VERSION: ${{ inputs.enterprise-version }}
+        GRADLE_SNAPSHOT_INIT_SCRIPT_PATH: ${{ inputs.gradle-snapshot-init-script-path }}
+        DOCKER_HUB_USERNAME: ${{ inputs.docker-hub-username }}
+        DOCKER_HUB_TOKEN: ${{ inputs.docker-hub-token }}
+        SETUP_SNAPSHOT_DOCKER_IMAGE: ${{ inputs.setup-snapshot-docker-image }}
       run: |
+        set -euo pipefail
+
+        if [[ -z "${ORCHESTRATOR_RUN_SUFFIX}" ]]; then
+          exit 0
+        fi
+
         echo "### Orchestrator" >> "$GITHUB_STEP_SUMMARY"
-        echo "Run: ${{ inputs.orchestrator-run-suffix }}" >> "$GITHUB_STEP_SUMMARY"
+        echo "Run: ${ORCHESTRATOR_RUN_SUFFIX}" >> "$GITHUB_STEP_SUMMARY"
 
-    - name: Install Gradle snapshot init script
-      if: ${{ inputs.orchestrator-run-suffix != '' && endsWith(inputs.enterprise-version, '-SNAPSHOT') && inputs.gradle-snapshot-init-script-path != '' }}
-      shell: bash
-      run: |
-        set -euo pipefail
+        if [[ ! "${ENTERPRISE_VERSION}" =~ -SNAPSHOT$ ]]; then
+          exit 0
+        fi
 
-        mkdir -p "$HOME/.gradle/init.d"
-        cp "${{ inputs.gradle-snapshot-init-script-path }}" "$HOME/.gradle/init.d/specmatic-snapshots.init.gradle"
+        if [[ -n "${GRADLE_SNAPSHOT_INIT_SCRIPT_PATH}" ]]; then
+          mkdir -p "$HOME/.gradle/init.d"
+          cp "${GRADLE_SNAPSHOT_INIT_SCRIPT_PATH}" "$HOME/.gradle/init.d/specmatic-snapshots.init.gradle"
+        fi
 
-    - name: Docker Login for orchestrator snapshot image
-      if: ${{ inputs.setup-snapshot-docker-image == 'true' && inputs.orchestrator-run-suffix != '' && endsWith(inputs.enterprise-version, '-SNAPSHOT') && inputs.docker-hub-username != '' && inputs.docker-hub-token != '' }}
-      shell: bash
-      run: echo "${{ inputs.docker-hub-token }}" | docker login -u "${{ inputs.docker-hub-username }}" --password-stdin
+        if [[ "${SETUP_SNAPSHOT_DOCKER_IMAGE}" == "true" ]]; then
+          if [[ -n "${DOCKER_HUB_USERNAME}" && -n "${DOCKER_HUB_TOKEN}" ]]; then
+            echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USERNAME}" --password-stdin
+          fi
 
-    - name: Prepare snapshot image for orchestrator run
-      if: ${{ inputs.setup-snapshot-docker-image == 'true' && inputs.orchestrator-run-suffix != '' && endsWith(inputs.enterprise-version, '-SNAPSHOT') }}
-      shell: bash
-      run: |
-        set -euo pipefail
-
-        docker pull specmatic/enterprise-snapshot
-        docker tag specmatic/enterprise-snapshot specmatic/enterprise:latest
+          docker pull specmatic/enterprise-snapshot
+          docker tag specmatic/enterprise-snapshot specmatic/enterprise:latest
+        fi

--- a/action-orchestrator-setup/action.yml
+++ b/action-orchestrator-setup/action.yml
@@ -44,30 +44,4 @@ runs:
         DOCKER_HUB_USERNAME: ${{ inputs.docker-hub-username }}
         DOCKER_HUB_TOKEN: ${{ inputs.docker-hub-token }}
         SETUP_SNAPSHOT_DOCKER_IMAGE: ${{ inputs.setup-snapshot-docker-image }}
-      run: |
-        set -euo pipefail
-
-        if [[ -z "${ORCHESTRATOR_RUN_SUFFIX}" ]]; then
-          exit 0
-        fi
-
-        echo "### Orchestrator" >> "$GITHUB_STEP_SUMMARY"
-        echo "Run: ${ORCHESTRATOR_RUN_SUFFIX}" >> "$GITHUB_STEP_SUMMARY"
-
-        if [[ ! "${ENTERPRISE_VERSION}" =~ -SNAPSHOT$ ]]; then
-          exit 0
-        fi
-
-        if [[ -n "${GRADLE_SNAPSHOT_INIT_SCRIPT_PATH}" ]]; then
-          mkdir -p "$HOME/.gradle/init.d"
-          cp "${GRADLE_SNAPSHOT_INIT_SCRIPT_PATH}" "$HOME/.gradle/init.d/specmatic-snapshots.init.gradle"
-        fi
-
-        if [[ "${SETUP_SNAPSHOT_DOCKER_IMAGE}" == "true" ]]; then
-          if [[ -n "${DOCKER_HUB_USERNAME}" && -n "${DOCKER_HUB_TOKEN}" ]]; then
-            echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USERNAME}" --password-stdin
-          fi
-
-          docker pull specmatic/enterprise-snapshot
-          docker tag specmatic/enterprise-snapshot specmatic/enterprise:latest
-        fi
+      run: ${{ github.action_path }}/prepare-orchestrator-runtime.sh

--- a/action-orchestrator-setup/action.yml
+++ b/action-orchestrator-setup/action.yml
@@ -1,0 +1,66 @@
+name: Orchestrator setup
+description: Shared workflow_dispatch setup for Specmatic orchestrator-triggered runs
+
+inputs:
+  orchestrator-run-suffix:
+    description: "Test Orchestrator run suffix"
+    required: false
+    default: ""
+
+  enterprise-version:
+    description: "Specmatic enterprise version under test"
+    required: false
+    default: ""
+
+  gradle-snapshot-init-script-path:
+    description: "Optional path to the Gradle init script to install for snapshot runs"
+    required: false
+    default: ""
+
+  docker-hub-username:
+    description: "Docker Hub username for snapshot image login"
+    required: false
+    default: ""
+
+  docker-hub-token:
+    description: "Docker Hub token for snapshot image login"
+    required: false
+    default: ""
+
+  setup-snapshot-docker-image:
+    description: "Whether to pull and retag the enterprise snapshot image"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Add orchestrator context to summary
+      if: ${{ inputs.orchestrator-run-suffix != '' }}
+      shell: bash
+      run: |
+        echo "### Orchestrator" >> "$GITHUB_STEP_SUMMARY"
+        echo "Run: ${{ inputs.orchestrator-run-suffix }}" >> "$GITHUB_STEP_SUMMARY"
+
+    - name: Install Gradle snapshot init script
+      if: ${{ inputs.orchestrator-run-suffix != '' && endsWith(inputs.enterprise-version, '-SNAPSHOT') && inputs.gradle-snapshot-init-script-path != '' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        mkdir -p "$HOME/.gradle/init.d"
+        cp "${{ inputs.gradle-snapshot-init-script-path }}" "$HOME/.gradle/init.d/specmatic-snapshots.init.gradle"
+
+    - name: Docker Login for orchestrator snapshot image
+      if: ${{ inputs.setup-snapshot-docker-image == 'true' && inputs.orchestrator-run-suffix != '' && endsWith(inputs.enterprise-version, '-SNAPSHOT') && inputs.docker-hub-username != '' && inputs.docker-hub-token != '' }}
+      shell: bash
+      run: echo "${{ inputs.docker-hub-token }}" | docker login -u "${{ inputs.docker-hub-username }}" --password-stdin
+
+    - name: Prepare snapshot image for orchestrator run
+      if: ${{ inputs.setup-snapshot-docker-image == 'true' && inputs.orchestrator-run-suffix != '' && endsWith(inputs.enterprise-version, '-SNAPSHOT') }}
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        docker pull specmatic/enterprise-snapshot
+        docker tag specmatic/enterprise-snapshot specmatic/enterprise:latest

--- a/action-orchestrator-setup/prepare-orchestrator-runtime.sh
+++ b/action-orchestrator-setup/prepare-orchestrator-runtime.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ -z "${ORCHESTRATOR_RUN_SUFFIX:-}" ]]; then
+  exit 0
+fi
+
+echo "### Orchestrator" >> "$GITHUB_STEP_SUMMARY"
+echo "Run: ${ORCHESTRATOR_RUN_SUFFIX}" >> "$GITHUB_STEP_SUMMARY"
+
+if [[ ! "${ENTERPRISE_VERSION:-}" =~ -SNAPSHOT$ ]]; then
+  exit 0
+fi
+
+if [[ -n "${GRADLE_SNAPSHOT_INIT_SCRIPT_PATH:-}" ]]; then
+  mkdir -p "$HOME/.gradle/init.d"
+  cp "${GRADLE_SNAPSHOT_INIT_SCRIPT_PATH}" "$HOME/.gradle/init.d/specmatic-snapshots.init.gradle"
+fi
+
+if [[ "${SETUP_SNAPSHOT_DOCKER_IMAGE:-false}" == "true" ]]; then
+  if [[ -n "${DOCKER_HUB_USERNAME:-}" && -n "${DOCKER_HUB_TOKEN:-}" ]]; then
+    echo "${DOCKER_HUB_TOKEN}" | docker login -u "${DOCKER_HUB_USERNAME}" --password-stdin
+  fi
+
+  docker pull specmatic/enterprise-snapshot
+  docker tag specmatic/enterprise-snapshot specmatic/enterprise:latest
+fi


### PR DESCRIPTION
## Summary
- add a reusable composite action for orchestrator-only workflow setup
- centralize the orchestrator summary step
- centralize optional snapshot init-script and snapshot Docker image setup

## Notes
- this keeps repo-local secrets and build logic in the consuming repositories
- README changes were left out of this PR intentionally to keep the review focused